### PR TITLE
decoder: Deduplicate keys also between multiple decoding, reduce max …

### DIFF
--- a/php_simdjson.h
+++ b/php_simdjson.h
@@ -62,11 +62,16 @@ extern zend_module_entry simdjson_module_entry;
 #define SIMDJSON_SUPPORT_URL                  "https://github.com/JakubOnderka/simdjson_php"
 
 #define SIMDJSON_PARSE_DEFAULT_DEPTH          512
-
-/*
+/**
  * Number of strings in array of array or object keys that will be deduplicated
  */
-#define SIMDJSON_REPEATED_STRINGS_COUNT       128
+#define SIMDJSON_DEDUP_STRING_COUNT       256
+/**
+ * Maximum length of strings to be considered for deduplication.
+ * Longer strings are less likely to be duplicated and the memory overhead
+ * of storing them in the hash table might exceed the benefits.
+ */
+#define SIMDJSON_MAX_DEDUP_LENGTH             64
 
 /*
  * NOTE: Namespaces and references(&) are C++ only functionality.

--- a/src/simdjson_decoder_defs.h
+++ b/src/simdjson_decoder_defs.h
@@ -22,7 +22,7 @@
 struct simdjson_php_parser {
 public:
     simdjson::dom::parser parser;
-    HashTable repeated_key_strings;
+    HashTable dedup_key_strings;
 };
 
 #endif

--- a/src/simdjson_encoder.cpp
+++ b/src/simdjson_encoder.cpp
@@ -564,7 +564,7 @@ static zend_always_inline void simdjson_escape_short_string(smart_str *buf, cons
 
 // Simplified version of php_next_utf8_char
 static unsigned int simdjson_get_next_char(const unsigned char *str, size_t str_len) {
-	if (!str_len >= 1)
+	if (str_len < 1)
 		return 1;
 
     /* We'll follow strategy 2. from section 3.6.1 of UTR #36:
@@ -576,7 +576,7 @@ static unsigned int simdjson_get_next_char(const unsigned char *str, size_t str_
     if (c < 0x80 || c < 0xc2) {
         return 1;
     } else if (c < 0xe0) {
-        if (!str_len >= 2)
+        if (str_len < 2)
             return 1;
 
         if (!utf8_trail(str[1])) {

--- a/tests/decode_repeated.phpt
+++ b/tests/decode_repeated.phpt
@@ -6,7 +6,7 @@ if (PHP_VERSION_ID < 80200) echo "skip deduplication is supported since PHP 8.2\
 ?>
 --FILE--
 <?php
-$json = '[{"ahoj":"svete"},{"ahoj":"moravo"}]';
+$json = '[{"ahoj":"svete"},{"ahoj":"moravo"},{"very_long_key_that_will_not_be_deduplicated_by_simdjson_extension":true},{"very_long_key_that_will_not_be_deduplicated_by_simdjson_extension":true}]';
 
 $value = \json_decode($json, true);
 debug_zval_dump(array_key_first($value[0]));
@@ -19,8 +19,24 @@ debug_zval_dump(@key($value[0]));
 
 $value = \simdjson_decode($json, false);
 debug_zval_dump(@key($value[0]));
---EXPECTF--
+
+$value = \json_decode($json, true);
+debug_zval_dump(array_key_first($value[2]));
+
+$value = \simdjson_decode($json, true);
+debug_zval_dump(array_key_first($value[2]));
+
+$value = \json_decode($json, false);
+debug_zval_dump(@key($value[2]));
+
+$value = \simdjson_decode($json, false);
+debug_zval_dump(@key($value[2]));
+--EXPECT--
 string(4) "ahoj" refcount(2)
-string(4) "ahoj" refcount(3)
+string(4) "ahoj" refcount(4)
 string(4) "ahoj" refcount(2)
-string(4) "ahoj" refcount(3)
+string(4) "ahoj" refcount(4)
+string(65) "very_long_key_that_will_not_be_deduplicated_by_simdjson_extension" refcount(2)
+string(65) "very_long_key_that_will_not_be_deduplicated_by_simdjson_extension" refcount(2)
+string(65) "very_long_key_that_will_not_be_deduplicated_by_simdjson_extension" refcount(2)
+string(65) "very_long_key_that_will_not_be_deduplicated_by_simdjson_extension" refcount(2)

--- a/tests/decode_repeated2.phpt
+++ b/tests/decode_repeated2.phpt
@@ -1,0 +1,24 @@
+--TEST--
+simdjson_decode repeated strings between calls
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID < 80200) echo "skip deduplication is supported since PHP 8.2\n";
+?>
+--FILE--
+<?php
+$json = '[{"ahoj":"svete"}]';
+
+$value1 = \simdjson_decode($json, true);
+debug_zval_dump(array_key_first($value1[0]));
+
+$value2 = \simdjson_decode($json, true);
+debug_zval_dump(array_key_first($value2[0]));
+
+simdjson_cleanup(); // removes also allocated strings
+
+debug_zval_dump(array_key_first($value1[0]));
+
+--EXPECT--
+string(4) "ahoj" refcount(3)
+string(4) "ahoj" refcount(4)
+string(4) "ahoj" refcount(3)


### PR DESCRIPTION
…string length to 64 chars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memory management for deduplicated key strings in JSON decoding.
  - Enhanced string length validation in character processing logic.

- **Tests**
  - Updated test case for JSON decoding with repeated and long keys to improve coverage.
  - Added a new test to verify deduplication behavior in repeated string decoding.

- **Documentation**
  - Updated constants and added documentation comments for clarity on deduplication limits.

These updates enhance memory handling and ensure robust parsing of JSON strings with complex key structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->