### PR TITLE
encoder: jsonSerialize as interned string

### DIFF
--- a/php_simdjson.cpp
+++ b/php_simdjson.cpp
@@ -47,6 +47,7 @@ PHP_SIMDJSON_API zend_class_entry *simdjson_base64_encode_ce;
 #include "simdjson_arginfo.h"
 
 static zend_string *simdjson_json_empty_array;
+zend_string *simdjson_json_serialize;
 
 ZEND_DECLARE_MODULE_GLOBALS(simdjson);
 
@@ -617,19 +618,23 @@ PHP_METHOD(SimdJsonBase64Encode, jsonSerialize) {
 */
 PHP_GINIT_FUNCTION (simdjson) {
 #if defined(COMPILE_DL_SIMDJSON) && defined(ZTS)
-ZEND_TSRMLS_CACHE_UPDATE();
+    ZEND_TSRMLS_CACHE_UPDATE();
 #endif
 }
 /* }}} */
+
+#define SIMDJSON_NEW_INTERNED_STRING(_dest, _string) do { \
+    _dest = zend_string_init_interned(_string, strlen(_string), 1); \
+    GC_ADD_FLAGS(_dest, IS_STR_VALID_UTF8); \
+} while(0); \
 
 /** {{{ PHP_MINIT_FUNCTION
 */
 PHP_MINIT_FUNCTION (simdjson) {
 #if PHP_VERSION_ID >= 80200
-    // Interned string for empty array
-    simdjson_json_empty_array = zend_new_interned_string(zend_string_init("[]", 2, 1));
-    GC_ADD_FLAGS(simdjson_json_empty_array, IS_STR_VALID_UTF8);
+    SIMDJSON_NEW_INTERNED_STRING(simdjson_json_empty_array, "[]");
 #endif
+    SIMDJSON_NEW_INTERNED_STRING(simdjson_json_serialize, "jsonSerialize");
 
     auto simdjson_exception_ce = register_class_SimdJsonException(spl_ce_RuntimeException);
 	simdjson_decoder_exception_ce = register_class_SimdJsonDecoderException(simdjson_exception_ce);

--- a/php_simdjson.h
+++ b/php_simdjson.h
@@ -117,6 +117,8 @@ extern PHP_SIMDJSON_API zend_class_entry *simdjson_decoder_exception_ce;
 extern PHP_SIMDJSON_API zend_class_entry *simdjson_encoder_exception_ce;
 extern PHP_SIMDJSON_API zend_class_entry *simdjson_base64_encode_ce;
 
+extern zend_string *simdjson_json_serialize;
+
 /**
  * NOTE: Namespaces and references(&) and classes (instead of structs) are C++ only functionality.
  *

--- a/src/simdjson_encoder.cpp
+++ b/src/simdjson_encoder.cpp
@@ -748,13 +748,12 @@ static zend_result simdjson_encode_serializable_object(smart_str *buf, zval *val
 	SIMDJSON_HASH_PROTECT_RECURSION(myht);
 #endif
 
-	ZVAL_STRING(&fname, "jsonSerialize");
+	ZVAL_INTERNED_STR(&fname, simdjson_json_serialize); // jsonSerialize
 
 	if (FAILURE == call_user_function(NULL, val, &fname, &retval, 0, NULL) || Z_TYPE(retval) == IS_UNDEF) {
 		if (!EG(exception)) {
 			zend_throw_exception_ex(NULL, 0, "Failed calling %s::jsonSerialize()", ZSTR_VAL(ce->name));
 		}
-		zval_ptr_dtor(&fname);
 #if PHP_VERSION_ID >= 80300
 		ZEND_GUARD_UNPROTECT_RECURSION(guard, JSON);
 #else
@@ -766,7 +765,6 @@ static zend_result simdjson_encode_serializable_object(smart_str *buf, zval *val
 	if (EG(exception)) {
 		/* Error already raised */
 		zval_ptr_dtor(&retval);
-		zval_ptr_dtor(&fname);
 #if PHP_VERSION_ID >= 80300
 		ZEND_GUARD_UNPROTECT_RECURSION(guard, JSON);
 #else
@@ -795,7 +793,6 @@ static zend_result simdjson_encode_serializable_object(smart_str *buf, zval *val
 	}
 
 	zval_ptr_dtor(&retval);
-	zval_ptr_dtor(&fname);
 
 	return return_code;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced JSON serialization capabilities in the simdjson PHP extension
	- Improved string handling for method name references

- **Refactor**
	- Optimized internal string management for JSON serialization
	- Updated method for referencing `jsonSerialize` method with interned strings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->