### PR TITLE
ci: Run build on ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,23 +41,26 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
-        os: [ubuntu-latest]
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
         experimental: [false]
     runs-on: ${{ matrix.os }}
     name: PHP ${{ matrix.php-version }} Test on ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     steps:
-      - name: "Checkout"
+      - name: Checkout
         uses: actions/checkout@v4
 
-      - name: "Install PHP"
+      - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: json
           # for correct php-config extension dir, see https://github.com/shivammathur/setup-php/issues/147
           tools: pecl, phpize, php-config
-      - name: "Build extension"
+
+      - name: Build extension
         run: |
           export NO_INTERACTION=true
           export REPORT_EXIT_STATUS=1
@@ -69,14 +72,14 @@ jobs:
           sudo make install
           make test TESTS="--show-diff -j2" || exit 1
 
-      - name: "Show"
+      - name: Show
         run: "php -dextension=simdjson.so --ri simdjson"
 
-      - name: "Error log"
+      - name: Error log
         if: ${{ failure() }}
         run: "ls -1t tests/*.log | xargs -d'\n' cat"
 
-      - name: "Error diff"
+      - name: Error diff
         if: ${{ failure() }}
         run: |
           for FILE in $(find tests -name '*.diff'); do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI workflow to add support for the "ubuntu-24.04-arm" runner in addition to "ubuntu-latest".
  - Improved formatting of step names in the workflow for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->