### PR TITLE
base64: simdjson_base64_encode allows to split encoded string to spec…

### DIFF
--- a/php_simdjson.cpp
+++ b/php_simdjson.cpp
@@ -739,7 +739,12 @@ PHP_FUNCTION(simdjson_base64_encode) {
         Z_PARAM_LONG(line_length)
     ZEND_PARSE_PARAMETERS_END();
 
-    if (UNEXPECTED(line_length)) {
+    if (UNEXPECTED(line_length != 0)) {
+        if (line_length < 0) {
+            zend_argument_value_error(3, "must be greater than 0");
+            RETURN_THROWS();
+        }
+
         auto options = url ? simdutf::base64_url : simdutf::base64_default;
         size_t encoded_length = simdutf::base64_length_from_binary_with_lines(ZSTR_LEN(str), options, line_length);
         output_string = zend_string_alloc(encoded_length, 0);

--- a/simdjson.stub.php
+++ b/simdjson.stub.php
@@ -410,8 +410,9 @@ function simdjson_base64_decode(string $string, bool $strict = false, bool $url 
 /**
  * @param string $string
  * @param bool $url Use base64url encoding according to RFC 4648 §5
+ * @param int $line_length
  * @return string
  * @compile-time-eval
  * @frameless-function {"arity": 1}
  */
-function simdjson_base64_encode(string $string, bool $url = false): string {}
+function simdjson_base64_encode(string $string, bool $url = false, int $line_length = 0): string {}

--- a/simdjson_arginfo.h
+++ b/simdjson_arginfo.h
@@ -91,7 +91,7 @@ ZEND_END_ARG_INFO()
 #if (PHP_VERSION_ID >= 80400)
 ZEND_FRAMELESS_FUNCTION(simdjson_is_valid_utf8, 1);
 static const zend_frameless_function_info frameless_function_infos_simdjson_is_valid_utf8[] = {
-	{ ZEND_FRAMELESS_FUNCTION_NAME(simdjson_is_valid_utf8, 1), 1 },
+	{ (void*)ZEND_FRAMELESS_FUNCTION_NAME(simdjson_is_valid_utf8, 1), 1 },
 	{ 0 },
 };
 #endif
@@ -99,7 +99,7 @@ static const zend_frameless_function_info frameless_function_infos_simdjson_is_v
 #if (PHP_VERSION_ID >= 80400)
 ZEND_FRAMELESS_FUNCTION(simdjson_utf8_len, 1);
 static const zend_frameless_function_info frameless_function_infos_simdjson_utf8_len[] = {
-	{ ZEND_FRAMELESS_FUNCTION_NAME(simdjson_utf8_len, 1), 1 },
+	{ (void*)ZEND_FRAMELESS_FUNCTION_NAME(simdjson_utf8_len, 1), 1 },
 	{ 0 },
 };
 #endif
@@ -107,7 +107,7 @@ static const zend_frameless_function_info frameless_function_infos_simdjson_utf8
 #if (PHP_VERSION_ID >= 80400)
 ZEND_FRAMELESS_FUNCTION(simdjson_base64_decode, 1);
 static const zend_frameless_function_info frameless_function_infos_simdjson_base64_decode[] = {
-	{ ZEND_FRAMELESS_FUNCTION_NAME(simdjson_base64_decode, 1), 1 },
+	{ (void*)ZEND_FRAMELESS_FUNCTION_NAME(simdjson_base64_decode, 1), 1 },
 	{ 0 },
 };
 #endif
@@ -115,7 +115,7 @@ static const zend_frameless_function_info frameless_function_infos_simdjson_base
 #if (PHP_VERSION_ID >= 80400)
 ZEND_FRAMELESS_FUNCTION(simdjson_base64_encode, 1);
 static const zend_frameless_function_info frameless_function_infos_simdjson_base64_encode[] = {
-	{ ZEND_FRAMELESS_FUNCTION_NAME(simdjson_base64_encode, 1), 1 },
+	{ (void*)ZEND_FRAMELESS_FUNCTION_NAME(simdjson_base64_encode, 1), 1 },
 	{ 0 },
 };
 #endif

--- a/simdjson_arginfo.h
+++ b/simdjson_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 2d27ab9518f0dcbc3439f69fa211cf232cee8598 */
+ * Stub hash: ec8a0fc5d7dc67c200e6def3e324985ff9d5388d */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_simdjson_validate, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, json, IS_STRING, 0)
@@ -73,6 +73,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_simdjson_base64_encode, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, url, _IS_BOOL, 0, "false")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, line_length, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_SimdJsonBase64Encode___construct, 0, 0, 1)
@@ -90,7 +91,7 @@ ZEND_END_ARG_INFO()
 #if (PHP_VERSION_ID >= 80400)
 ZEND_FRAMELESS_FUNCTION(simdjson_is_valid_utf8, 1);
 static const zend_frameless_function_info frameless_function_infos_simdjson_is_valid_utf8[] = {
-	{ (void*)ZEND_FRAMELESS_FUNCTION_NAME(simdjson_is_valid_utf8, 1), 1 },
+	{ ZEND_FRAMELESS_FUNCTION_NAME(simdjson_is_valid_utf8, 1), 1 },
 	{ 0 },
 };
 #endif
@@ -98,7 +99,7 @@ static const zend_frameless_function_info frameless_function_infos_simdjson_is_v
 #if (PHP_VERSION_ID >= 80400)
 ZEND_FRAMELESS_FUNCTION(simdjson_utf8_len, 1);
 static const zend_frameless_function_info frameless_function_infos_simdjson_utf8_len[] = {
-	{ (void*)ZEND_FRAMELESS_FUNCTION_NAME(simdjson_utf8_len, 1), 1 },
+	{ ZEND_FRAMELESS_FUNCTION_NAME(simdjson_utf8_len, 1), 1 },
 	{ 0 },
 };
 #endif
@@ -106,7 +107,7 @@ static const zend_frameless_function_info frameless_function_infos_simdjson_utf8
 #if (PHP_VERSION_ID >= 80400)
 ZEND_FRAMELESS_FUNCTION(simdjson_base64_decode, 1);
 static const zend_frameless_function_info frameless_function_infos_simdjson_base64_decode[] = {
-	{ (void*)ZEND_FRAMELESS_FUNCTION_NAME(simdjson_base64_decode, 1), 1 },
+	{ ZEND_FRAMELESS_FUNCTION_NAME(simdjson_base64_decode, 1), 1 },
 	{ 0 },
 };
 #endif
@@ -114,7 +115,7 @@ static const zend_frameless_function_info frameless_function_infos_simdjson_base
 #if (PHP_VERSION_ID >= 80400)
 ZEND_FRAMELESS_FUNCTION(simdjson_base64_encode, 1);
 static const zend_frameless_function_info frameless_function_infos_simdjson_base64_encode[] = {
-	{ (void*)ZEND_FRAMELESS_FUNCTION_NAME(simdjson_base64_encode, 1), 1 },
+	{ ZEND_FRAMELESS_FUNCTION_NAME(simdjson_base64_encode, 1), 1 },
 	{ 0 },
 };
 #endif
@@ -305,9 +306,7 @@ static zend_class_entry *register_class_SimdJsonBase64Encode(zend_class_entry *c
 
 	zval property_string_default_value;
 	ZVAL_UNDEF(&property_string_default_value);
-	zend_string *property_string_name = zend_string_init("string", sizeof("string") - 1, 1);
-	zend_declare_typed_property(class_entry, property_string_name, &property_string_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_string_name);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_STRING), &property_string_default_value, ZEND_ACC_PRIVATE, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 
 	zval property_base64url_default_value;
 	ZVAL_FALSE(&property_base64url_default_value);

--- a/src/simdjson_compatibility.h
+++ b/src/simdjson_compatibility.h
@@ -24,36 +24,6 @@
 #endif
 #endif // #ifndef ZEND_FALLTHROUGH
 
-#if PHP_VERSION_ID < 80100
-/* Check if an array is a list */
-static int zend_array_is_list(HashTable *myht) {
-    int i;
-    i = myht ? zend_hash_num_elements(myht) : 0;
-    if (i > 0) {
-        zend_string *key;
-        zend_ulong index, idx;
-
-        if (HT_IS_PACKED(myht) && HT_IS_WITHOUT_HOLES(myht)) {
-            return 1;
-        }
-
-        idx = 0;
-        ZEND_HASH_FOREACH_KEY(myht, index, key) {
-            if (key) {
-                return 0;
-            } else {
-                if (index != idx) {
-                    return 0;
-                }
-            }
-            idx++;
-        } ZEND_HASH_FOREACH_END();
-    }
-
-    return 1;
-}
-#endif
-
 #if PHP_VERSION_ID < 80200
 static zend_always_inline bool zend_string_equals_cstr(const zend_string *s1, const char *s2, size_t s2_length) {
     return ZSTR_LEN(s1) == s2_length && !memcmp(ZSTR_VAL(s1), s2, s2_length);

--- a/src/simdjson_decoder.cpp
+++ b/src/simdjson_decoder.cpp
@@ -618,14 +618,12 @@ static simdjson_php_error_code simdjson_convert_element(simdjson::dom::element e
     // Allocate table for reusing already allocated keys
     simdjson_dedup_key_strings_init(&parser->dedup_key_strings, parser->dedup_key_strings_data);
 #endif
-    simdjson_php_error_code resp;
     if (associative) {
         simdjson_create_array(parser, element, return_value);
-        resp = simdjson::SUCCESS;
+        return simdjson::SUCCESS;
     } else {
-        resp = simdjson_create_object(parser, element, return_value);
+        return simdjson_create_object(parser, element, return_value);
     }
-    return resp;
 }
 
 static simdjson_php_error_code simdjson_ondemand_validate(simdjson::ondemand::value element, size_t max_depth) {

--- a/src/simdjson_encoder.h
+++ b/src/simdjson_encoder.h
@@ -37,7 +37,7 @@ struct _simdjson_encoder {
     php_stream *stream;
 };
 
-// max lenght of escaped string is 6 chars, but we coping 8 bytes is faster on 64 platforms
+// max length of escaped string is 6 chars, but we coping 8 bytes is faster on 64 platforms
 #define SIMDJSON_ENCODER_ESCAPE_LENGTH 8
 
 typedef struct {

--- a/tests/base64/base64_encode_line_length.phpt
+++ b/tests/base64/base64_encode_line_length.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test simdjson_base64_encode() function : line length
+--FILE--
+<?php
+$input = <<<TEXT
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ac scelerisque nisi. Vestibulum congue, lacus non tincidunt rhoncus, metus velit ultrices lorem, vel cursus dolor elit vitae libero. Donec ut ante ultricies, fringilla mauris in, dapibus libero. Aliquam fringilla lectus non auctor congue. Proin sodales eleifend erat in tincidunt. Morbi pellentesque nulla ac elit luctus, eget accumsan tortor porttitor. Pellentesque elementum dui vitae ipsum finibus efficitur.
+TEXT;
+echo simdjson_base64_encode($input, false, 76);
+--EXPECT--
+TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4g
+RG9uZWMgYWMgc2NlbGVyaXNxdWUgbmlzaS4gVmVzdGlidWx1bSBjb25ndWUsIGxhY3VzIG5vbiB0
+aW5jaWR1bnQgcmhvbmN1cywgbWV0dXMgdmVsaXQgdWx0cmljZXMgbG9yZW0sIHZlbCBjdXJzdXMg
+ZG9sb3IgZWxpdCB2aXRhZSBsaWJlcm8uIERvbmVjIHV0IGFudGUgdWx0cmljaWVzLCBmcmluZ2ls
+bGEgbWF1cmlzIGluLCBkYXBpYnVzIGxpYmVyby4gQWxpcXVhbSBmcmluZ2lsbGEgbGVjdHVzIG5v
+biBhdWN0b3IgY29uZ3VlLiBQcm9pbiBzb2RhbGVzIGVsZWlmZW5kIGVyYXQgaW4gdGluY2lkdW50
+LiBNb3JiaSBwZWxsZW50ZXNxdWUgbnVsbGEgYWMgZWxpdCBsdWN0dXMsIGVnZXQgYWNjdW1zYW4g
+dG9ydG9yIHBvcnR0aXRvci4gUGVsbGVudGVzcXVlIGVsZW1lbnR1bSBkdWkgdml0YWUgaXBzdW0g
+ZmluaWJ1cyBlZmZpY2l0dXIu


### PR DESCRIPTION
…ific line length

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * simdjson_base64_encode gains an optional line_length parameter to produce line-wrapped Base64 output (default 0 preserves existing behavior).

* **Tests**
  * Added test verifying Base64 output is wrapped at the requested line length.

* **Chores / Refactor**
  * Simplified decoder control flow, removed an obsolete compatibility helper, and fixed a minor comment typo.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->