### PR TITLE
decoder: Disable read buffer for simdjson_decode_from_stream

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,9 +27,10 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.3.29"
-          - "8.4.16"
-          - "8.5.1"
+          - "8.2.30"
+          - "8.3.30"
+          - "8.4.17"
+          - "8.5.2"
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"

--- a/docker-dev
+++ b/docker-dev
@@ -7,7 +7,7 @@ RUN apt-get update && \
 ARG PHP_VERSION=8.4.16
 RUN curl -L https://www.php.net/distributions/php-$PHP_VERSION.tar.xz | tar xJf - && \
     cd php-$PHP_VERSION && \
-    ./configure --enable-debug --without-sqlite3 --disable-pdo --disable-dom --disable-simplexml --without-pdo-sqlite && \
+    ./configure --enable-debug --without-sqlite3 --disable-pdo --disable-dom --disable-simplexml --disable-phar --without-pdo-sqlite && \
     make -j$(nproc) && \
     make install && \
     rm -rf /php-$PHP_VERSION

--- a/php_simdjson.cpp
+++ b/php_simdjson.cpp
@@ -157,7 +157,7 @@ template <bool with_padding> static char *simdjson_stream_copy_to_mem(php_stream
 
 #ifdef ZEND_DEBUG
         // Set padding to zero to make valgrind happy
-        memset(ptr, 0, simdjson::SIMDJSON_PADDING);
+        memset(result + *len, 0, simdjson::SIMDJSON_PADDING);
 #endif
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster, more efficient full-stream reading path for improved parse throughput and reduced read overhead.

* **Bug Fixes & Stability**
  * More robust handling of streamed input lengths, reducing partial-read and non-seekable stream issues.

* **Memory & Safety**
  * Safer import and padding of stream contents to reduce buffer risks and improve decoding stability.

* **Chores**
  * CI matrix updated and PHP build config adjusted to disable PHAR in the development image.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->