### PR TITLE
encoder: Optimise encoding of SplFixedArray

### DIFF
--- a/src/simdjson_encoder.cpp
+++ b/src/simdjson_encoder.cpp
@@ -755,7 +755,7 @@ static void simdjson_encode_base64_object(smart_str *buf, const zval *val) {
 }
 
 #if PHP_VERSION_ID >= 80300
-static zend_result simdjson_encode_spl_fixedarray(smart_str *buf, const zval *obj, simdjson_encoder *encoder) {
+static zend_result simdjson_encode_spl_fixedarray(smart_str *buf, const zval *val, simdjson_encoder *encoder) {
     struct simdjson_spl_fixedarray {
         zend_long size;
         zval *elements;
@@ -768,7 +768,8 @@ static zend_result simdjson_encode_spl_fixedarray(smart_str *buf, const zval *ob
         zend_object             std;
     };
 
-    simdjson_spl_fixedarray_object *intern = (simdjson_spl_fixedarray_object *)((char *)Z_OBJ_P(obj) - XtOffsetOf(simdjson_spl_fixedarray_object, std));
+    zend_object *obj = Z_OBJ_P(val);
+    simdjson_spl_fixedarray_object *intern = (simdjson_spl_fixedarray_object *)((char *)obj - XtOffsetOf(simdjson_spl_fixedarray_object, std));
 
     if (intern->array.elements == NULL) {
         ZEND_ASSERT(intern->array.size == 0);
@@ -778,6 +779,13 @@ static zend_result simdjson_encode_spl_fixedarray(smart_str *buf, const zval *ob
 
     ZEND_ASSERT(intern->array.size > 0);
 
+    if (GC_IS_RECURSIVE(obj)) {
+        encoder->error_code = SIMDJSON_ERROR_RECURSION;
+        return FAILURE;
+    }
+
+    SIMDJSON_HASH_PROTECT_RECURSION(obj);
+
     simdjson_smart_str_appendc(buf, '[');
     ++encoder->depth;
 
@@ -785,10 +793,13 @@ static zend_result simdjson_encode_spl_fixedarray(smart_str *buf, const zval *ob
         simdjson_pretty_print_nl_ident(buf, encoder);
         zval *current = &intern->array.elements[i];
         if (UNEXPECTED(simdjson_encode_zval(buf, current, encoder) == FAILURE)) {
+            SIMDJSON_HASH_UNPROTECT_RECURSION(obj);
             return FAILURE;
         }
         simdjson_smart_str_appendc(buf, ',');
     }
+
+    SIMDJSON_HASH_UNPROTECT_RECURSION(obj);
 
     ZSTR_LEN(buf->s)--; // remove last comma
 

--- a/src/simdjson_encoder.cpp
+++ b/src/simdjson_encoder.cpp
@@ -390,7 +390,7 @@ static zend_result simdjson_encode_packed_array(smart_str *buf, HashTable *table
 
     ZEND_ASSERT(recursion_rc != NULL);
 
-	if (GC_IS_RECURSIVE(recursion_rc)) {
+	if (UNEXPECTED(GC_IS_RECURSIVE(recursion_rc))) {
 		encoder->error_code = SIMDJSON_ERROR_RECURSION;
 		return FAILURE;
 	}
@@ -433,7 +433,7 @@ static zend_result simdjson_encode_mixed_array(smart_str *buf, HashTable *table,
 
     ZEND_ASSERT(recursion_rc != NULL);
 
-	if (GC_IS_RECURSIVE(recursion_rc)) {
+	if (UNEXPECTED(GC_IS_RECURSIVE(recursion_rc))) {
 		encoder->error_code = SIMDJSON_ERROR_RECURSION;
 		return FAILURE;
 	}
@@ -501,7 +501,7 @@ static zend_result simdjson_encode_simple_object(smart_str *buf, zval *val, simd
 	zend_property_info *prop_info;
 	zval *prop;
 
-	if (GC_IS_RECURSIVE(obj)) {
+	if (UNEXPECTED(GC_IS_RECURSIVE(obj))) {
 		encoder->error_code = SIMDJSON_ERROR_RECURSION;
 		return FAILURE;
 	}
@@ -580,7 +580,7 @@ static zend_result simdjson_encode_object(smart_str *buf, zval *val, simdjson_en
     recursion_rc = (zend_refcounted *)myht;
 #endif
 
-    if (GC_IS_RECURSIVE(recursion_rc)) {
+    if (UNEXPECTED(GC_IS_RECURSIVE(recursion_rc))) {
         encoder->error_code = SIMDJSON_ERROR_RECURSION;
         zend_release_properties(myht);
         return FAILURE;
@@ -779,7 +779,7 @@ static zend_result simdjson_encode_spl_fixedarray(smart_str *buf, const zval *va
 
     ZEND_ASSERT(intern->array.size > 0);
 
-    if (GC_IS_RECURSIVE(obj)) {
+    if (UNEXPECTED(GC_IS_RECURSIVE(obj))) {
         encoder->error_code = SIMDJSON_ERROR_RECURSION;
         return FAILURE;
     }
@@ -826,7 +826,7 @@ static zend_result simdjson_encode_serializable_object(smart_str *buf, zval *val
 	uint32_t *guard = zend_get_recursion_guard(obj);
 	ZEND_ASSERT(guard != NULL);
 
-	if (ZEND_GUARD_IS_RECURSIVE(guard, JSON)) {
+	if (UNEXPECTED(ZEND_GUARD_IS_RECURSIVE(guard, JSON))) {
 		encoder->error_code = SIMDJSON_ERROR_RECURSION;
 		return FAILURE;
 	}
@@ -835,7 +835,7 @@ static zend_result simdjson_encode_serializable_object(smart_str *buf, zval *val
 #else
 	HashTable* myht = Z_OBJPROP_P(val);
 
-	if (GC_IS_RECURSIVE(myht)) {
+	if (UNEXPECTED(GC_IS_RECURSIVE(myht))) {
 		encoder->error_code = SIMDJSON_ERROR_RECURSION;
 		return FAILURE;
 	}

--- a/src/simdjson_encoder.cpp
+++ b/src/simdjson_encoder.cpp
@@ -25,6 +25,7 @@ extern "C" {
 #include "zend_portability.h"
 #include <zend_exceptions.h>
 #include "ext/json/php_json.h" /* For php_json_serializable_ce */
+#include "ext/spl/spl_fixedarray.h" /* For spl_ce_SplFixedArray */
 #if PHP_VERSION_ID >= 80400
 #include "zend_property_hooks.h"
 #include "zend_lazy_objects.h"
@@ -753,6 +754,57 @@ static void simdjson_encode_base64_object(smart_str *buf, const zval *val) {
     *output = '"';
 }
 
+#if PHP_VERSION_ID >= 80300
+static zend_result simdjson_encode_spl_fixedarray(smart_str *buf, const zval *obj, simdjson_encoder *encoder) {
+    struct simdjson_spl_fixedarray {
+        zend_long size;
+        zval *elements;
+        zend_long cached_resize;
+    };
+
+    struct simdjson_spl_fixedarray_object {
+        simdjson_spl_fixedarray array;
+        zend_function          *fptr_count;
+        zend_object             std;
+    };
+
+    simdjson_spl_fixedarray_object *intern = (simdjson_spl_fixedarray_object *)((char *)Z_OBJ_P(obj) - XtOffsetOf(simdjson_spl_fixedarray_object, std));
+
+    if (intern->array.elements == NULL) {
+        ZEND_ASSERT(intern->array.size == 0);
+        simdjson_smart_str_appendl(buf, "[]", 2);
+        return SUCCESS;
+    }
+
+    ZEND_ASSERT(intern->array.size > 0);
+
+    simdjson_smart_str_appendc(buf, '[');
+    ++encoder->depth;
+
+    for (zend_long i = 0; i < intern->array.size; i++) {
+        simdjson_pretty_print_nl_ident(buf, encoder);
+        zval *current = &intern->array.elements[i];
+        if (UNEXPECTED(simdjson_encode_zval(buf, current, encoder) == FAILURE)) {
+            return FAILURE;
+        }
+        simdjson_smart_str_appendc(buf, ',');
+    }
+
+    ZSTR_LEN(buf->s)--; // remove last comma
+
+    if (UNEXPECTED(encoder->depth > encoder->max_depth)) {
+        encoder->error_code = SIMDJSON_ERROR_DEPTH;
+        return FAILURE;
+    }
+    --encoder->depth;
+
+    simdjson_pretty_print_nl_ident(buf, encoder);
+    simdjson_smart_str_appendc(buf, ']');
+
+    return SUCCESS;
+}
+#endif
+
 static zend_result simdjson_encode_serializable_object(smart_str *buf, zval *val, simdjson_encoder *encoder) {
 	zend_class_entry *ce = Z_OBJCE_P(val);
 	zend_object *obj = Z_OBJ_P(val);
@@ -879,6 +931,11 @@ again:
                 simdjson_encode_base64_object(buf, val);
                 return SUCCESS;
             }
+#if PHP_VERSION_ID >= 80300
+	        if (Z_OBJCE_P(val) == spl_ce_SplFixedArray) {
+	            return simdjson_encode_spl_fixedarray(buf, val, encoder);
+	        }
+#endif
 			if (instanceof_function_slow(Z_OBJCE_P(val), php_json_serializable_ce)) {
 				return simdjson_encode_serializable_object(buf, val, encoder);
 			}

--- a/src/simdjson_encoder.cpp
+++ b/src/simdjson_encoder.cpp
@@ -768,6 +768,11 @@ static zend_result simdjson_encode_spl_fixedarray(smart_str *buf, const zval *va
         zend_object             std;
     };
 
+    if (UNEXPECTED(simdjson_check_stack_limit())) {
+        encoder->error_code = SIMDJSON_ERROR_DEPTH;
+        return FAILURE;
+    }
+
     zend_object *obj = Z_OBJ_P(val);
     simdjson_spl_fixedarray_object *intern = (simdjson_spl_fixedarray_object *)((char *)obj - XtOffsetOf(simdjson_spl_fixedarray_object, std));
 

--- a/tests/encode/simdjson_encode_spl_fixedarray.phpt
+++ b/tests/encode/simdjson_encode_spl_fixedarray.phpt
@@ -1,0 +1,53 @@
+--TEST--
+Test simdjson_encode() function : SplFixedArray
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID < 80200) echo "skip SplFixedArray implemenets jsonSerialize since PHP 8.2\n";
+?>
+--FILE--
+<?php
+error_reporting(E_ALL ^ E_DEPRECATED);
+
+// Empty array
+var_dump(simdjson_encode(new SplFixedArray(0)));
+
+// Array with one element
+$array = new SplFixedArray(1);
+$array[0] = 1;
+var_dump(simdjson_encode($array));
+
+// Array with size 2 but with only one element
+$array = new SplFixedArray(2);
+$array[0] = 1;
+var_dump(simdjson_encode($array));
+
+// Object with dynamic property - it is not serialized to JSON
+$array = new SplFixedArray(2);
+$array[0] = 1;
+$array->test = "test";
+var_dump(simdjson_encode($array));
+
+class CustomFixedArray extends SplFixedArray {
+}
+var_dump(simdjson_encode(new CustomFixedArray(0)));
+
+$array = new CustomFixedArray(1);
+$array[0] = 1;
+var_dump(simdjson_encode($array));
+
+class FixedArrayWithCustomJsonSerialize extends SplFixedArray {
+    public function jsonSerialize(): array {
+        return [2];
+    }
+}
+$array = new FixedArrayWithCustomJsonSerialize(1);
+$array[0] = 1;
+var_dump(simdjson_encode($array));
+--EXPECT--
+string(2) "[]"
+string(3) "[1]"
+string(8) "[1,null]"
+string(8) "[1,null]"
+string(2) "[]"
+string(3) "[1]"
+string(3) "[2]"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for encoding PHP `SplFixedArray` values with `simdjson_encode()`.
  * Supports empty, partially populated, nested, subclassed, and custom-serialized fixed arrays.
  * Dynamic properties are ignored, and encoding failures are handled consistently.

* **Tests**
  * Added coverage for empty and populated arrays, unfilled slots, subclasses, custom serialization, nesting, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->